### PR TITLE
Progressive stub removal, angle merge after simplification

### DIFF
--- a/planetiler-core/src/main/java/com/onthegomap/planetiler/FeatureMerge.java
+++ b/planetiler-core/src/main/java/com/onthegomap/planetiler/FeatureMerge.java
@@ -191,7 +191,7 @@ public class FeatureMerge {
         List<LineString> outputSegments = new ArrayList<>();
         var i = 0;
         for (Object merged : merger.getMergedLineStrings()) {
-          if (merged instanceof LineString line && line.getLength() >= lengthLimit) {
+          if (merged instanceof LineString line) {
             // TODO remove debug features comment
             // Map<String, Object> attrs = new HashMap<>();
             // attrs.put("idx", i++);
@@ -216,10 +216,23 @@ public class FeatureMerge {
             }
           }
         }
+        
+        merger = new LoopLineMerger();
+        for (var outputSegment : outputSegments) {
+          merger.add(outputSegment);
+        }
+        outputSegments = merger.getMergedByAngle();
+
         if (!outputSegments.isEmpty()) {
           outputSegments = sortByHilbertIndex(outputSegments);
           Geometry newGeometry = GeoUtils.combineLineStrings(outputSegments);
           result.add(feature1.copyWithNewGeometry(newGeometry));
+          // i = 0;
+          // for (var outputSegment : outputSegments) {
+          //   Map<String, Object> attrs = new HashMap<>();
+          //   attrs.put("idx", ++i);
+          //   result.add(feature1.copyWithNewGeometry(outputSegment).copyWithExtraAttrs(attrs));
+          // }
         }
       }
     }

--- a/planetiler-core/src/main/java/com/onthegomap/planetiler/util/LoopLineMerger.java
+++ b/planetiler-core/src/main/java/com/onthegomap/planetiler/util/LoopLineMerger.java
@@ -7,6 +7,7 @@ import java.util.HashMap;
 import java.util.List;
 import java.util.Map;
 import java.util.PriorityQueue;
+import org.locationtech.jts.algorithm.Angle;
 import org.locationtech.jts.geom.Coordinate;
 import org.locationtech.jts.geom.CoordinateXY;
 import org.locationtech.jts.geom.Geometry;
@@ -14,6 +15,7 @@ import org.locationtech.jts.geom.GeometryComponentFilter;
 import org.locationtech.jts.geom.GeometryFactory;
 import org.locationtech.jts.geom.LineString;
 import org.locationtech.jts.geom.PrecisionModel;
+
 
 public class LoopLineMerger {
   final List<LineString> input = new ArrayList<>();
@@ -75,16 +77,48 @@ public class LoopLineMerger {
       if (node.getEdges().size() == 2) {
         Edge a = node.getEdges().getFirst();
         Edge b = node.getEdges().get(1);
+        mergeTwoEdges(a, b);
         node.getEdges().clear();
-        List<Coordinate> coordinates = new ArrayList<>();
-        coordinates.addAll(a.coordinates.reversed());
-        coordinates.addAll(b.coordinates.subList(1, b.coordinates.size()));
-        Edge c = new Edge(a.to, b.to, coordinates, a.length + b.length);
-        a.to.removeEdge(a.reversed);
-        b.to.removeEdge(b.reversed);
-        a.to.addEdge(c);
-        if (a.to != b.to) {
-          b.to.addEdge(c.reversed);
+      }
+    }
+  }
+
+  private void mergeTwoEdges(Edge a, Edge b) {
+    List<Coordinate> coordinates = new ArrayList<>();
+    coordinates.addAll(a.coordinates.reversed());
+    coordinates.addAll(b.coordinates.subList(1, b.coordinates.size()));
+    Edge c = new Edge(a.to, b.to, coordinates, a.length + b.length);
+    a.to.removeEdge(a.reversed);
+    b.to.removeEdge(b.reversed);
+    a.to.addEdge(c);
+    if (a.to != b.to) {
+      b.to.addEdge(c.reversed);
+    }
+  }
+
+  private void mergeByAngle() {
+    for (var node : output) {
+      List<Edge> edges = List.copyOf(node.getEdges());
+      if (edges.size() >= 3) {
+        record AngledPair(Edge a, Edge b, double angle) {}
+        List<AngledPair> angledPairs = new ArrayList<>();
+        for (var i = 0; i < edges.size(); ++i) {
+          for (var j = i + 1; j < edges.size(); ++j) {
+            double angle = edges.get(i).angleTo(edges.get(j));
+            angledPairs.add(new AngledPair(edges.get(i), edges.get(j), angle));
+          }
+        }
+        angledPairs.sort(Comparator.comparingDouble(angledPair -> angledPair.angle));
+        List<Edge> merged = new ArrayList<>();
+        for (var angledPair : angledPairs.reversed()) {
+          if (merged.contains(angledPair.a) || merged.contains(angledPair.b)) {
+            continue;
+          }
+          mergeTwoEdges(angledPair.a, angledPair.b);
+          node.getEdges().remove(angledPair.a);
+          node.getEdges().remove(angledPair.b);
+          merged.add(angledPair.a);
+          merged.add(angledPair.b);
         }
       }
     }
@@ -152,10 +186,10 @@ public class LoopLineMerger {
     return Double.POSITIVE_INFINITY;
   }
 
-  private void removeShortStubEdges() {
+  private void removeShortStubEdges(double stubMinLength) {
     for (var node : output) {
       for (var edge : List.copyOf(node.getEdges())) {
-        if (edge.length < minLength &&
+        if (edge.length < stubMinLength &&
           (edge.from.getEdges().size() == 1 || edge.to.getEdges().size() == 1 || edge.from == edge.to)) {
           edge.remove();
         }
@@ -185,11 +219,36 @@ public class LoopLineMerger {
     }
 
     if (minLength > 0.0) {
-      removeShortStubEdges();
+      double step = 1.0 / precisionModel.getScale();
+      for (double stubMinLength = 0.0; stubMinLength < minLength; stubMinLength += step) {
+        removeShortStubEdges(stubMinLength);
+        merge();
+      }
+      removeShortStubEdges(minLength);
       merge();
-      removeShortEdges();
-      merge();
+      // minLength = 10 * 0.0625;
+      // removeShortEdges();
+      // merge();
     }
+
+    List<LineString> result = new ArrayList<>();
+
+    for (var node : output) {
+      for (var edge : node.getEdges()) {
+        if (edge.main) {
+          result.add(factory.createLineString(edge.coordinates.toArray(Coordinate[]::new)));
+        }
+      }
+    }
+
+    return result;
+  }
+
+  public List<LineString> getMergedByAngle() {
+    List<List<Coordinate>> edges = nodeLines(input);
+    buildNodes(edges);
+
+    mergeByAngle();
 
     List<LineString> result = new ArrayList<>();
 
@@ -358,6 +417,24 @@ public class LoopLineMerger {
     public void remove() {
       from.removeEdge(this);
       to.removeEdge(reversed);
+    }
+
+    double angleTo(Edge other) {
+      if (!from.equals(other.from)) {
+        // Todo raise some error, the edges don't start at same coordinate
+        System.out.println("error start point mismatch");
+        return 0.0;
+      }
+      if (coordinates.size() < 2 || other.coordinates.size() < 2) {
+        // todo no real linestring...
+        System.out.println("error lines are points");
+        return 0.0;
+      }
+
+      double angle = Angle.angle(coordinates.get(0), coordinates.get(1));
+      double angleOther = Angle.angle(other.coordinates.get(0), other.coordinates.get(1));
+      
+      return Math.abs(Angle.normalize(angle - angleOther));
     }
 
     @Override

--- a/planetiler-core/src/main/java/com/onthegomap/planetiler/util/LoopLineMerger.java
+++ b/planetiler-core/src/main/java/com/onthegomap/planetiler/util/LoopLineMerger.java
@@ -78,12 +78,14 @@ public class LoopLineMerger {
         Edge a = node.getEdges().getFirst();
         Edge b = node.getEdges().get(1);
         mergeTwoEdges(a, b);
-        node.getEdges().clear();
       }
     }
   }
 
   private void mergeTwoEdges(Edge a, Edge b) {
+    assert a.to == b.from;
+    a.to.getEdges().remove(a);
+    b.from.getEdges().remove(b);
     List<Coordinate> coordinates = new ArrayList<>();
     coordinates.addAll(a.coordinates.reversed());
     coordinates.addAll(b.coordinates.subList(1, b.coordinates.size()));
@@ -115,8 +117,6 @@ public class LoopLineMerger {
             continue;
           }
           mergeTwoEdges(angledPair.a, angledPair.b);
-          node.getEdges().remove(angledPair.a);
-          node.getEdges().remove(angledPair.b);
           merged.add(angledPair.a);
           merged.add(angledPair.b);
         }
@@ -420,16 +420,8 @@ public class LoopLineMerger {
     }
 
     double angleTo(Edge other) {
-      if (!from.equals(other.from)) {
-        // Todo raise some error, the edges don't start at same coordinate
-        System.out.println("error start point mismatch");
-        return 0.0;
-      }
-      if (coordinates.size() < 2 || other.coordinates.size() < 2) {
-        // todo no real linestring...
-        System.out.println("error lines are points");
-        return 0.0;
-      }
+      assert from.equals(other.from); 
+      assert coordinates.size() >= 2;
 
       double angle = Angle.angle(coordinates.get(0), coordinates.get(1));
       double angleOther = Angle.angle(other.coordinates.get(0), other.coordinates.get(1));


### PR DESCRIPTION
Implements 2 ideas:

## Progressive stub removal

When we set the min length and remove stubs, we usually remove all of them in one go. But it might make sense to remove them progressively because we keep more. Consider for example this:

![image](https://github.com/user-attachments/assets/30822919-2390-4952-b2dc-4816ced63c5d)

If we set min length = 4, then with the old version we loose all but the line 0 to 5. What this pr does is that it removes first all the stubs with length 1, then all the stubs with length 2, ..., 4 and in between we merge the graph. Like that the result is a continuous line from 0 to 8.

## Angle merge

After simplification, we merge lines at nodes with more than 2 edges prioritizing merging by angle between edges. Edges that for large angles get merged first. This creates nice long linestrings for transportation_name and other layers that wand to do label placement...